### PR TITLE
Change "label" to "layout" in _construct_simple

### DIFF
--- a/ipywidgets_jsonschema/form.py
+++ b/ipywidgets_jsonschema/form.py
@@ -266,7 +266,7 @@ class Form:
                 0,
                 ipywidgets.Label(
                     title,
-                    label=ipywidgets.Layout(width="100%"),
+                    layout=ipywidgets.Layout(width="100%"),
                     tooltip=tooltip,
                 ),
             )


### PR DESCRIPTION
This looks like a typo, I believe this should be "layout" not "label?"